### PR TITLE
disable noAssignInExpressions and noParameterAssign

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "docs": "jsdoc -c jsdoc.json",
         "start": "npx http-server -o src/index.html",
         "format": "npx @biomejs/biome format --write src",
-        "lint": "npx @biomejs/biome lint src",
+        "lint": "npx @biomejs/biome lint src --skip=style/noParameterAssign --skip=suspicious/noAssignInExpressions",
         "unsafe-fix": "npx @biomejs/biome lint --write --unsafe src",
         "check": "npx @biomejs/biome check --write src"
     },


### PR DESCRIPTION
Closes #63 add skip arguments to disable noAssignInExpressions and noParameterAssign. Tested and works locally.